### PR TITLE
Add failing test for wss connection behind TLS-terminating reverse proxy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,9 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.0'
     testImplementation 'io.nats:jnats-server-runner:1.2.8'
     testImplementation 'nl.jqno.equalsverifier:equalsverifier:3.12.3'
+    testImplementation 'org.testcontainers:junit-jupiter:1.19.2'
+    testImplementation 'org.testcontainers:nginx:1.19.2'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.11'
 }
 
 sourceSets {

--- a/src/test/java/io/nats/client/impl/WebsocketConnectTests.java
+++ b/src/test/java/io/nats/client/impl/WebsocketConnectTests.java
@@ -16,10 +16,14 @@ package io.nats.client.impl;
 import io.nats.client.*;
 import io.nats.client.support.HttpRequest;
 import io.nats.client.utils.CloseOnUpgradeAttempt;
+import io.nats.client.utils.ResourceUtils;
 import io.nats.client.utils.RunProxy;
 import io.nats.client.utils.TestBase;
 import nats.io.NatsServerRunner;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.NginxContainer;
+import org.testcontainers.images.builder.Transferable;
+import org.testcontainers.utility.MountableFile;
 
 import javax.net.ssl.SSLContext;
 import java.io.IOException;
@@ -318,5 +322,57 @@ public class WebsocketConnectTests extends TestBase {
                 Nats.connect(options);
             }
         });
+    }
+
+    @Test
+    public void testSecureWebsocketBehindTLSTerminatingProxy() throws Exception {
+        int natsWebsocketPort = NatsTestServer.nextPort();
+        try (NatsTestServer ts = new NatsTestServer(null, getWebsocketConfig(natsWebsocketPort), 0, false);
+             NginxContainer<?> nginxContainer = runNginxContainer(natsWebsocketPort)) {
+            String proxySecureWebsocketURL = "wss://" + nginxContainer.getHost() + ":" + nginxContainer.getMappedPort(443);
+            SSLContext ctx = TestSSLUtils.createTestSSLContext();
+            assertCanConnect(
+                    Options.builder()
+                            .server(proxySecureWebsocketURL)
+                            .sslContext(ctx)
+                            .build()
+            );
+        }
+    }
+
+    @Test
+    public void testWebsocketBehindProxy() throws Exception {
+        int natsWebsocketPort = NatsTestServer.nextPort();
+        try (NatsTestServer ts = new NatsTestServer(null, getWebsocketConfig(natsWebsocketPort), 0, false);
+             NginxContainer<?> nginxContainer = runNginxContainer(natsWebsocketPort)) {
+            String proxyWebsocketURL = "ws://" + nginxContainer.getHost() + ":" + nginxContainer.getMappedPort(80);
+            assertCanConnect(
+                    Options.builder()
+                            .server(proxyWebsocketURL)
+                            .build()
+            );
+        }
+    }
+
+    NginxContainer<?> runNginxContainer(int proxyTargetPort) {
+        String proxyTargetURL = "http://host.testcontainers.internal:" + proxyTargetPort;
+        String baseConfig = ResourceUtils.resourceAsString("nginx/base.conf");
+        String modifiedConfig = baseConfig.replace("PROXY_TARGET_URL", proxyTargetURL);
+        org.testcontainers.Testcontainers.exposeHostPorts(proxyTargetPort);
+        NginxContainer<?> nginx = new NginxContainer<>("nginx:1.23.4-alpine")
+                .withCopyFileToContainer(MountableFile.forClasspathResource("certs/"), "/etc/ssl/")
+                .withCopyToContainer(Transferable.of(modifiedConfig), "/etc/nginx/conf.d/default.conf")
+                .withExposedPorts(80, 443);
+        nginx.start();
+        return nginx;
+    }
+
+    public static String[] getWebsocketConfig(int websocketPort) {
+        return new String[] {
+                "websocket {",
+                "  listen: \"localhost:" + websocketPort + "\"",
+                "  no_tls: true",
+                "}"
+        };
     }
 }

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,21 @@
+<!--
+  ~ Copyright 2023 flex Inc. - All Rights Reserved.
+  -->
+
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="org.testcontainers" level="INFO"/>
+    <!-- The following logger can be used for containers logs since 1.18.0 -->
+    <logger name="tc" level="INFO"/>
+    <logger name="com.github.dockerjava" level="WARN"/>
+    <logger name="com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.wire" level="OFF"/>
+</configuration>

--- a/src/test/resources/nginx/base.conf
+++ b/src/test/resources/nginx/base.conf
@@ -1,0 +1,17 @@
+server {
+    listen 80;
+    listen 443 ssl;
+    server_name localhost;
+
+    ssl_certificate     /etc/ssl/server.pem;
+    ssl_certificate_key /etc/ssl/key.pem;
+    ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers         ALL:@SECLEVEL=0;
+
+    location / {
+        proxy_pass PROXY_TARGET_URL;
+
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}


### PR DESCRIPTION
Add integration test using Nginx testcontainer.

Request flow
nats-java --> nginx --> nats-server

`testSecureWebsocketBehindTLSTerminatingProxy` test fails but if you apply https://github.com/nats-io/nats.java/pull/1041 it passes